### PR TITLE
lien 2.0.0

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -363,7 +363,7 @@ class LienObj {
         if (!customRoot) {
             customRoot = this.server.options.public[0][1];
         }
-        filePath = path.join(customRoot, filePath);
+        filePath = path.resolve(customRoot, filePath);
         this.res.sendFile(filePath);
     }
 }
@@ -580,9 +580,7 @@ module.exports = class Lien extends EventEmitter {
         let router = ~url.indexOf(":") ? this.router : this.beforeRequest;
 
         router[method](url, (req, res, next) => {
-
             let trans = this.getHooks("before", req.path, req.method.toLowerCase());
-
             if (trans) {
                 let lien = new LienObj(req, res, next, this);
                 trans.start(lien, (err, data) => {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "test": "node test/index.js"
   },
   "name": "lien",
-  "version": "1.6.1",
+  "version": "2.0.0",
   "description": "Another lightweight NodeJS framework. Lien is the link between request and response objects.",
   "main": "lib/index.js",
   "keywords": [

--- a/test/index.js
+++ b/test/index.js
@@ -47,7 +47,7 @@ tester.describe("lien", t => {
         });
 
         // Add a static file
-        server.addPage("/test", "/index.html");
+        server.addPage("/test", "index.html");
         server.errorPages();
 
         server.on("serverError", err => {


### PR DESCRIPTION
The `addPage("/route", "path/to/file")` can accept an absolute path to the file. This is useful when serving resources which are not in the public folder.