### PR TITLE
lien 2.2.0

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -164,7 +164,10 @@ Adds a new page to be handled.
 
 #### Params
 - **String** `url`: The page url.
-- **String** `method`: The request methods to be handled (default: `"all"`).
+- **String|Object** `method`: The request methods to be handled (default: `"all"`) or an object:
+ - `method` (String): The HTTP method.
+ - `before` (Array|Function): A function or an array of middleware functions to be executed *before* the main function.
+ - `after` (Array|Function): A function or an array of middleware functions to be executed *after* the main function.
 - **Function** `output`: A function receiving the `lien` object as parameter. If can be a path serving a public file.
 
 ### `errorPages(options)`

--- a/README.md
+++ b/README.md
@@ -218,7 +218,10 @@ Adds a new page to be handled.
 
 #### Params
 - **String** `url`: The page url.
-- **String** `method`: The request methods to be handled (default: `"all"`).
+- **String|Object** `method`: The request methods to be handled (default: `"all"`) or an object:
+ - `method` (String): The HTTP method.
+ - `before` (Array|Function): A function or an array of middleware functions to be executed *before* the main function.
+ - `after` (Array|Function): A function or an array of middleware functions to be executed *after* the main function.
 - **Function** `output`: A function receiving the `lien` object as parameter. If can be a path serving a public file.
 
 ### `errorPages(options)`

--- a/lib/index.js
+++ b/lib/index.js
@@ -421,7 +421,7 @@ class LienObj {
  *
  * @return {Object} The Lien instance.
  */
-module.exports = class Lien extends EventEmitter {
+class Lien extends EventEmitter {
     constructor (options) {
 
         super();
@@ -567,7 +567,12 @@ module.exports = class Lien extends EventEmitter {
      * @name addPage
      * @function
      * @param {String} url The page url.
-     * @param {String} method The request methods to be handled (default: `"all"`).
+     * @param {String|Object} method The request methods to be handled (default: `"all"`) or an object:
+     *
+     *  - `method` (String): The HTTP method.
+     *  - `before` (Array|Function): A function or an array of middleware functions to be executed *before* the main function.
+     *  - `after` (Array|Function): A function or an array of middleware functions to be executed *after* the main function.
+     *
      * @param {Function} output A function receiving the `lien` object as parameter. If can be a path serving a public file.
      */
     addPage (url, method, output) {
@@ -578,8 +583,21 @@ module.exports = class Lien extends EventEmitter {
         }
 
         let router = typeof url === "string" && ~url.indexOf(":") ? this.router : this.beforeRequest;
-
-        router[method](url, (req, res, next) => {
+        let before = []
+        let after = []
+        if (method && method.method) {
+            before = method.before || [];
+            if (!Array.isArray(before)) {
+                before = [before];
+            }
+            after = method.after || [];
+            if (!Array.isArray(after)) {
+                after = [after];
+            }
+            method = method.method;
+        }
+        let funcs = [].concat(before);
+        funcs.push((req, res, next) => {
             let trans = this.getHooks("before", req.path, req.method.toLowerCase());
             if (trans) {
                 let lien = new LienObj(req, res, next, this);
@@ -591,6 +609,9 @@ module.exports = class Lien extends EventEmitter {
                 this._handleRoute(req, res, output, [], next);
             }
         });
+        funcs = funcs.concat(after);
+
+        router[method].apply(router, [url].concat(funcs.filter(Boolean)));
     }
 
     /**
@@ -726,4 +747,7 @@ module.exports = class Lien extends EventEmitter {
         trans.add(cb, transType);
         return this;
     }
-};
+}
+
+Lien.LienObj = LienObj;
+module.exports = Lien;

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "test": "node test/index.js"
   },
   "name": "lien",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "Another lightweight NodeJS framework. Lien is the link between request and response objects.",
   "main": "lib/index.js",
   "keywords": [


### PR DESCRIPTION
Make the middleware functions adding easier.

We can use the `before` and `after` options to control the endpoint handlers.

Also, the `LienObj` class is now exported as `Lien.LienObj`.