### PR TITLE
lien 2.2.1

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -153,8 +153,10 @@ It emits the following events:
  - `errorPages` (Object):
    - `notFound` (String|Function): The path to a custom 404 page or a function receiving the lien object as parameter. This can be used to serve custom 404 pages.
    - `serverError` (String|Function): The path to a custom 500 page or a function receiving the lien object as parameter. This can be used to serve custom 500 pages.
+   - `badCsrf` (String|Function):  The path to a custom bad CSRF page or a function receiving the lien object as parameter. This can be used to serve custom bad CSRF errors.
 
  - `logErrors` (Boolean): Log the server errors (default: `true`).
+ - `csrf` (Object): The CSRF options. These are passed to [`csurf`](https://github.com/expressjs/csurf)
 
 #### Return
 - **Object** The Lien instance.

--- a/README.md
+++ b/README.md
@@ -207,8 +207,10 @@ It emits the following events:
  - `errorPages` (Object):
    - `notFound` (String|Function): The path to a custom 404 page or a function receiving the lien object as parameter. This can be used to serve custom 404 pages.
    - `serverError` (String|Function): The path to a custom 500 page or a function receiving the lien object as parameter. This can be used to serve custom 500 pages.
+   - `badCsrf` (String|Function):  The path to a custom bad CSRF page or a function receiving the lien object as parameter. This can be used to serve custom bad CSRF errors.
 
  - `logErrors` (Boolean): Log the server errors (default: `true`).
+ - `csrf` (Object): The CSRF options. These are passed to [`csurf`](https://github.com/expressjs/csurf)
 
 #### Return
 - **Object** The Lien instance.

--- a/lib/index.js
+++ b/lib/index.js
@@ -22,6 +22,7 @@ const events = require("events")
     , iterateObject = require("iterate-object")
     , noop = require("noop6")
     , cookieParser = require("cookie-parser")
+    , csrf = require("csurf")
     ;
 
 class LienObj {
@@ -59,6 +60,12 @@ class LienObj {
         this.server = server;
         this.data = req.body;
         this.session = req.session;
+        Object.defineProperty(this, "csrfToken", {
+            get: () => (this.req.csrfToken && this.req.csrfToken()) || ""
+        });
+        Object.defineProperty(this, "csrfInput", {
+            get: () => this.req.csrfToken ? `<input type="hidden" name="_csrf" value="${this.req.csrfToken()}">` : ""
+        });
 
         this.full_path = req.originalUrl;
         this.protocol = req.protocol;
@@ -169,7 +176,7 @@ class LienObj {
     getSessionData (field) {
         if (!this._checkSessionSupport()) { return; }
         if (field) {
-            return findValue(this.session._sessionData, field);
+            return findValue(this.session._sessionData, field) || null;
         }
         return this.session._sessionData;
     }
@@ -243,6 +250,7 @@ class LienObj {
      * @param {Number} status The status code (default: `422`).
      */
     apiError (msg, status) {
+        msg = msg.message || msg;
         this.apiMsg(msg, status || 422)
     }
 
@@ -416,8 +424,10 @@ class LienObj {
  *  - `errorPages` (Object):
  *    - `notFound` (String|Function): The path to a custom 404 page or a function receiving the lien object as parameter. This can be used to serve custom 404 pages.
  *    - `serverError` (String|Function): The path to a custom 500 page or a function receiving the lien object as parameter. This can be used to serve custom 500 pages.
+ *    - `badCsrf` (String|Function):  The path to a custom bad CSRF page or a function receiving the lien object as parameter. This can be used to serve custom bad CSRF errors.
  *
  *  - `logErrors` (Boolean): Log the server errors (default: `true`).
+ *  - `csrf` (Object): The CSRF options. These are passed to [`csurf`](https://github.com/expressjs/csurf)
  *
  * @return {Object} The Lien instance.
  */
@@ -431,8 +441,16 @@ class Lien extends EventEmitter {
           , session: false
           , errorPages: {}
           , logErrors: true
+          , csrf: null
         });
 
+        if (options.csrf === true) {
+            options.csrf = {
+                cookie: true
+            };
+        }
+
+        this.csrf = options.csrf ? csrf(options.csrf) : null;
         this.express = express;
         this.router = express.Router();
         this.beforeRequest = express.Router();
@@ -452,11 +470,9 @@ class Lien extends EventEmitter {
         app.use(bodyParser.json());
         app.use(bodyParser.urlencoded({ extended: true }));
 
-        if (options.cookies) {
-            app.use(cookieParser(options.cookies));
-        }
-
         this.MongoStore = connectMongo(session);
+
+        app.use(cookieParser());
 
         if (options.session) {
             options.session = ul.merge(options.session, {
@@ -583,7 +599,7 @@ class Lien extends EventEmitter {
         }
 
         let router = typeof url === "string" && ~url.indexOf(":") ? this.router : this.beforeRequest;
-        let before = []
+        let before = [this.csrf]
         let after = []
         if (method && method.method) {
             before = method.before || [];
@@ -637,11 +653,16 @@ class Lien extends EventEmitter {
         options = ul.merge(options, {
             notFound: lien => sendResp(lien, "404 — Not found.", 404)
           , serverError: lien => sendResp(lien, "500 — Internal Server Error", 500)
+          , badCsrf: lien => sendResp(lien, "What‽ Your browser did something unexpected.", 422)
         });
         this.app.use((req, res, next) =>
             this._handleRoute(req, res, options.notFound, [], next)
         );
         this.app.use((err, req, res, next) => {
+            if (err.code === "EBADCSRFTOKEN") {
+                return this._handleRoute(req, res, options.badCsrf, [err], next)
+            }
+
             this.emit("serverError", err, req, res);
             if (this.options.logErrors) {
                 console.error(err.stack);

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "test": "node test/index.js"
   },
   "name": "lien",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "Another lightweight NodeJS framework. Lien is the link between request and response objects.",
   "main": "lib/index.js",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "body-parser": "^1.15.0",
     "connect-mongo": "^1.1.0",
     "cookie-parser": "^1.4.3",
+    "csurf": "^1.9.0",
     "express": "^4.13.4",
     "express-session": "^1.13.0",
     "find-value": "^1.0.1",


### PR DESCRIPTION
Add support for CSRF.

Disabled by default, CSRF functionality can be enabled using the `csrf:true` option.