### PR TITLE
LienJS 3.0.0

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -4,6 +4,7 @@ You can see below the API reference of this module.
 
 ### `LienCreator(req, res, next, server)`
 Creates the `lien` object.
+
 #### Params
 - **Object** `req`: The request object.
 - **Object** `res`: The response object.
@@ -21,28 +22,33 @@ Go to the next middleware handler.
 
 ### `redirect(newUrl, query)`
 Redirects the client to another url.
+
 #### Params
 - **String** `newUrl`: The new url to redirect to.
 - **Boolean|Object** `query`: If `true`, the request querystring parameters will be appended. If it's an object, it will be merged with the request querystring parameters.
 
 ### `render(template, data)`
 Renders a template to the client.
+
 #### Params
 - **String** `template`: The template name.
 - **Object** `data`: The template data.
 
 ### `startSession(data)`
 Starts a session.
+
 #### Params
 - **Object** `data`: The session data.
 
 ### `setSessionData(data)`
 Sets the session data.
+
 #### Params
 - **Object** `data`: The session data.
 
 ### `getSessionData(field)`
 Returns the session data object/specific field.
+
 #### Params
 - **Field** `field`: A specific field to get from the session object.
 
@@ -54,6 +60,7 @@ Destroys the session.
 
 ### `header(name, value)`
 Gets/sets/deletes headers.
+
 #### Params
 - **String** `name`: The header name.
 - **String** `value`: The header value to set. If `null`, the header will be *removed*.
@@ -63,18 +70,21 @@ Gets/sets/deletes headers.
 
 ### `apiMsg(msg, status)`
 Sends to the client a JSON object containing the `message` field.
+
 #### Params
 - **String** `msg`: The API message.
 - **Number** `status`: The status code (default: `200`).
 
 ### `apiError(msg, status)`
 Like `apiMsg`, but by default with a status code of `422`.
+
 #### Params
 - **String** `msg`: The API message.
 - **Number** `status`: The status code (default: `422`).
 
 ### `end(content, status, contentType, headers)`
 Ends the response sending the content.
+
 #### Params
 - **Anything** `content`: The content that should be sent to the response.
 - **Number** `status`: The status code.
@@ -83,6 +93,7 @@ Ends the response sending the content.
 
 ### `cookie(cookie, value)`
 Sets, gets or deletes the cookie.
+
 #### Params
 - **String** `cookie`: The searched cookie.
 - **String** `value`: If provided and it not `null`, the cookie will be set. If it's null, the cookie will be deleted. If `value` is not provided, the cookie value will be returned.
@@ -92,6 +103,7 @@ Sets, gets or deletes the cookie.
 
 ### `file(path, customRoot)`
 Serves a file to the response.
+
 #### Params
 - **String** `path`: Relative path to the file.
 - **String** `customRoot`: Absolute path to the root directory (optional).
@@ -104,7 +116,9 @@ It extends the `EventEmitter` class.
 It emits the following events:
 
  - `load` (err): After the server is started. If there are no errors, the `err` will be null.
- - `serverError` (err, req, res): The server unexpected error.
+ - `serverError` (err, req, res): This is emitted when something goes wrong after the server is started.
+ - `error` (err): Errors which may appear during the server initialization.
+
 #### Params
 - **Object** `opt_options`: An object containing the following properties:
  - `host` (String): The server host.
@@ -114,8 +128,8 @@ It emits the following events:
    - `resave` (Boolean): Forces the session to be saved back to the session store, even if the session was never modified during the request (default: false).
    - `saveUninitialized` (Boolean): Forces a session that is "uninitialized" to be saved to the store (default: `true`).
    - `cookie` (Object): The cookie [options](https://github.com/expressjs/cookie-parser).
-   - `storeOptions` (Object): The [MongoStore options](https://github.com/kcbanner/connect-mongo).
-   - `store`: (Object): A custom store object (optional, as long `storeOptions` is provided).
+   - `storeOptions` (Object): The session store options. These options are passed to the session store you choose.
+   - `store`: (String|Function): The session store name or function. By default it's using a memory store if the session is enabled.
  - `public` (String|Array): The path to the public directory or an array of arrays in this format: `["/url/of/static/dir", "path/to/static/dir"]`.
 
    Example:
@@ -148,8 +162,16 @@ It emits the following events:
 #### Return
 - **Object** The Lien instance.
 
+### `addStaticPath(url, localPath)`
+Adds a new static path to the server.
+
+#### Params
+- **String** `url`: The static path url endpoint.
+- **String** `localPath`: The local path to the directory.
+
 ### `addPage(url, method, output)`
 Adds a new page to be handled.
+
 #### Params
 - **String** `url`: The page url.
 - **String|Object** `method`: The request methods to be handled (default: `"all"`) or an object:
@@ -160,6 +182,7 @@ Adds a new page to be handled.
 
 ### `errorPages(options)`
 Handle the error pages.
+
 #### Params
 - **Object** `options`: An object containing the following fields:
  - `notFound` (String|Function): The path to a custom 404 page or a function receiving the lien object as parameter. This can be used to serve custom 404 pages.
@@ -167,6 +190,7 @@ Handle the error pages.
 
 ### `getHooks(type, url, method)`
 Gets the transformer for a url.
+
 #### Params
 - **String** `type`: The hook type (`before` or `after`).
 - **String** `url`: The url.
@@ -178,6 +202,7 @@ Gets the transformer for a url.
 ### `getHooksStrict(type, url, method)`
 Similar to `getHooks`, but doesn't concat hooks based on the regex
 matching but only if they are the same regex.
+
 #### Params
 - **String** `type`: The hook type (`before` or `after`).
 - **String** `url`: The url.
@@ -188,6 +213,7 @@ matching but only if they are the same regex.
 
 ### `insertHook(type, url, method, trans)`
 Inserts a new hook.
+
 #### Params
 - **String** `type`: The hook type (`before`, `after`, `custom:name`).
 - **String** `url`: The url.
@@ -199,8 +225,36 @@ Inserts a new hook.
 
 ### `hook(where, url, method, cb, transType)`
 Adds a new hook.
+
 #### Params
 - **String** `where`: The hook type (`before` or `after`).
+- **String** `url`: The route url.
+- **String** `method`: The HTTP method.
+- **Function** `cb`: The callback function.
+- **Number** `transType`: The transformer type.
+
+### `before(url, method, cb, transType)`
+Adds a before hook. It will handle all the subroutes of the `url`.
+
+#### Params
+- **String** `url`: The route url.
+- **String** `method`: The HTTP method.
+- **Function** `cb`: The callback function.
+- **Number** `transType`: The transformer type.
+
+### `after(url, method, cb, transType)`
+Adds a before hook. It will handle all the subroutes of the `url`.
+
+#### Params
+- **String** `url`: The route url.
+- **String** `method`: The HTTP method.
+- **Function** `cb`: The callback function.
+- **Number** `transType`: The transformer type.
+
+### `use(url, method, cb, transType)`
+Use this function to add middleware handlers.
+
+#### Params
 - **String** `url`: The route url.
 - **String** `method`: The HTTP method.
 - **Function** `cb`: The callback function.

--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@
 
 # lien
 
- [![Patreon](https://img.shields.io/badge/Support%20me%20on-Patreon-%23e6461a.svg)][patreon] [![PayPal](https://img.shields.io/badge/%24-paypal-f39c12.svg)][paypal-donations] [![AMA](https://img.shields.io/badge/ask%20me-anything-1abc9c.svg)](https://github.com/IonicaBizau/ama) [![Travis](https://img.shields.io/travis/LienJS/Lien.svg)](https://travis-ci.org/LienJS/Lien/) [![Version](https://img.shields.io/npm/v/lien.svg)](https://www.npmjs.com/package/lien) [![Downloads](https://img.shields.io/npm/dt/lien.svg)](https://www.npmjs.com/package/lien) [![Get help on Codementor](https://cdn.codementor.io/badges/get_help_github.svg)](https://www.codementor.io/johnnyb?utm_source=github&utm_medium=button&utm_term=johnnyb&utm_campaign=github)
+ [![Support me on Patreon][badge_patreon]][patreon] [![Buy me a book][badge_amazon]][amazon] [![PayPal][badge_paypal_donate]][paypal-donations] [![Travis](https://img.shields.io/travis/LienJS/Lien.svg)](https://travis-ci.org/LienJS/Lien/) [![Version](https://img.shields.io/npm/v/lien.svg)](https://www.npmjs.com/package/lien) [![Downloads](https://img.shields.io/npm/dt/lien.svg)](https://www.npmjs.com/package/lien)
 
-> Another lightweight NodeJS framework. Lien is the link between request and response objects.
+> An easy to use web framework for Node.js.
 
 ## :cloud: Installation
 
@@ -22,10 +22,9 @@ $ npm i --save lien
 const Lien = require("lien");
 
 // Init lien server
-let server = new Lien({
-    host: "localhost"
-  , port: 9000
-  , public: __dirname + "/public"
+const server = new Lien({
+    port: 9000
+  , public: `${__dirname}/public`
 });
 
 // Listen for load
@@ -35,29 +34,39 @@ server.on("load", err => {
 });
 
 // Add page
-server.addPage("/", lien => {
+server.get("/", lien => {
     lien.end("Hello World");
 });
 
 // Add a dynamic route
-server.addPage("/post/:id", lien => {
+server.get("/post/:id", lien => {
     lien.end("Post id: " + lien.params.id);
 });
 
 // Add a static file
-server.addPage("/test", "/index.html");
-server.errorPages();
+server.get("/test", "index.html");
 
+// Listen for server errors
 server.on("serverError", err => {
     console.log(err.stack);
 });
 ```
+
+## :question: Get Help
+
+There are few ways to get help:
+
+ 1. Please [post questions on Stack Overflow](https://stackoverflow.com/questions/ask). You can open issues with questions, as long you add a link to your Stack Overflow question.
+ 2. For bug reports and feature requests, open issues. :bug:
+ 3. For direct and quick help from me, you can [use Codementor](https://www.codementor.io/johnnyb). :rocket:
+
 
 ## :memo: Documentation
 
 
 ### `LienCreator(req, res, next, server)`
 Creates the `lien` object.
+
 #### Params
 - **Object** `req`: The request object.
 - **Object** `res`: The response object.
@@ -75,28 +84,33 @@ Go to the next middleware handler.
 
 ### `redirect(newUrl, query)`
 Redirects the client to another url.
+
 #### Params
 - **String** `newUrl`: The new url to redirect to.
 - **Boolean|Object** `query`: If `true`, the request querystring parameters will be appended. If it's an object, it will be merged with the request querystring parameters.
 
 ### `render(template, data)`
 Renders a template to the client.
+
 #### Params
 - **String** `template`: The template name.
 - **Object** `data`: The template data.
 
 ### `startSession(data)`
 Starts a session.
+
 #### Params
 - **Object** `data`: The session data.
 
 ### `setSessionData(data)`
 Sets the session data.
+
 #### Params
 - **Object** `data`: The session data.
 
 ### `getSessionData(field)`
 Returns the session data object/specific field.
+
 #### Params
 - **Field** `field`: A specific field to get from the session object.
 
@@ -108,6 +122,7 @@ Destroys the session.
 
 ### `header(name, value)`
 Gets/sets/deletes headers.
+
 #### Params
 - **String** `name`: The header name.
 - **String** `value`: The header value to set. If `null`, the header will be *removed*.
@@ -117,18 +132,21 @@ Gets/sets/deletes headers.
 
 ### `apiMsg(msg, status)`
 Sends to the client a JSON object containing the `message` field.
+
 #### Params
 - **String** `msg`: The API message.
 - **Number** `status`: The status code (default: `200`).
 
 ### `apiError(msg, status)`
 Like `apiMsg`, but by default with a status code of `422`.
+
 #### Params
 - **String** `msg`: The API message.
 - **Number** `status`: The status code (default: `422`).
 
 ### `end(content, status, contentType, headers)`
 Ends the response sending the content.
+
 #### Params
 - **Anything** `content`: The content that should be sent to the response.
 - **Number** `status`: The status code.
@@ -137,6 +155,7 @@ Ends the response sending the content.
 
 ### `cookie(cookie, value)`
 Sets, gets or deletes the cookie.
+
 #### Params
 - **String** `cookie`: The searched cookie.
 - **String** `value`: If provided and it not `null`, the cookie will be set. If it's null, the cookie will be deleted. If `value` is not provided, the cookie value will be returned.
@@ -146,6 +165,7 @@ Sets, gets or deletes the cookie.
 
 ### `file(path, customRoot)`
 Serves a file to the response.
+
 #### Params
 - **String** `path`: Relative path to the file.
 - **String** `customRoot`: Absolute path to the root directory (optional).
@@ -158,7 +178,9 @@ It extends the `EventEmitter` class.
 It emits the following events:
 
  - `load` (err): After the server is started. If there are no errors, the `err` will be null.
- - `serverError` (err, req, res): The server unexpected error.
+ - `serverError` (err, req, res): This is emitted when something goes wrong after the server is started.
+ - `error` (err): Errors which may appear during the server initialization.
+
 #### Params
 - **Object** `opt_options`: An object containing the following properties:
  - `host` (String): The server host.
@@ -168,8 +190,8 @@ It emits the following events:
    - `resave` (Boolean): Forces the session to be saved back to the session store, even if the session was never modified during the request (default: false).
    - `saveUninitialized` (Boolean): Forces a session that is "uninitialized" to be saved to the store (default: `true`).
    - `cookie` (Object): The cookie [options](https://github.com/expressjs/cookie-parser).
-   - `storeOptions` (Object): The [MongoStore options](https://github.com/kcbanner/connect-mongo).
-   - `store`: (Object): A custom store object (optional, as long `storeOptions` is provided).
+   - `storeOptions` (Object): The session store options. These options are passed to the session store you choose.
+   - `store`: (String|Function): The session store name or function. By default it's using a memory store if the session is enabled.
  - `public` (String|Array): The path to the public directory or an array of arrays in this format: `["/url/of/static/dir", "path/to/static/dir"]`.
 
    Example:
@@ -202,8 +224,16 @@ It emits the following events:
 #### Return
 - **Object** The Lien instance.
 
+### `addStaticPath(url, localPath)`
+Adds a new static path to the server.
+
+#### Params
+- **String** `url`: The static path url endpoint.
+- **String** `localPath`: The local path to the directory.
+
 ### `addPage(url, method, output)`
 Adds a new page to be handled.
+
 #### Params
 - **String** `url`: The page url.
 - **String|Object** `method`: The request methods to be handled (default: `"all"`) or an object:
@@ -214,6 +244,7 @@ Adds a new page to be handled.
 
 ### `errorPages(options)`
 Handle the error pages.
+
 #### Params
 - **Object** `options`: An object containing the following fields:
  - `notFound` (String|Function): The path to a custom 404 page or a function receiving the lien object as parameter. This can be used to serve custom 404 pages.
@@ -221,6 +252,7 @@ Handle the error pages.
 
 ### `getHooks(type, url, method)`
 Gets the transformer for a url.
+
 #### Params
 - **String** `type`: The hook type (`before` or `after`).
 - **String** `url`: The url.
@@ -232,6 +264,7 @@ Gets the transformer for a url.
 ### `getHooksStrict(type, url, method)`
 Similar to `getHooks`, but doesn't concat hooks based on the regex
 matching but only if they are the same regex.
+
 #### Params
 - **String** `type`: The hook type (`before` or `after`).
 - **String** `url`: The url.
@@ -242,6 +275,7 @@ matching but only if they are the same regex.
 
 ### `insertHook(type, url, method, trans)`
 Inserts a new hook.
+
 #### Params
 - **String** `type`: The hook type (`before`, `after`, `custom:name`).
 - **String** `url`: The url.
@@ -253,8 +287,36 @@ Inserts a new hook.
 
 ### `hook(where, url, method, cb, transType)`
 Adds a new hook.
+
 #### Params
 - **String** `where`: The hook type (`before` or `after`).
+- **String** `url`: The route url.
+- **String** `method`: The HTTP method.
+- **Function** `cb`: The callback function.
+- **Number** `transType`: The transformer type.
+
+### `before(url, method, cb, transType)`
+Adds a before hook. It will handle all the subroutes of the `url`.
+
+#### Params
+- **String** `url`: The route url.
+- **String** `method`: The HTTP method.
+- **Function** `cb`: The callback function.
+- **Number** `transType`: The transformer type.
+
+### `after(url, method, cb, transType)`
+Adds a before hook. It will handle all the subroutes of the `url`.
+
+#### Params
+- **String** `url`: The route url.
+- **String** `method`: The HTTP method.
+- **Function** `cb`: The callback function.
+- **Number** `transType`: The transformer type.
+
+### `use(url, method, cb, transType)`
+Use this function to add middleware handlers.
+
+#### Params
 - **String** `url`: The route url.
 - **String** `method`: The HTTP method.
 - **Function** `cb`: The callback function.
@@ -266,14 +328,22 @@ Adds a new hook.
 Have an idea? Found a bug? See [how to contribute][contributing].
 
 
-## :moneybag: Donations
+## :sparkling_heart: Support my projects
 
-Another way to support the development of my open-source modules is
-to [set up a recurring donation, via Patreon][patreon]. :rocket:
+I open-source almost everything I can, and I try to reply everyone needing help using these projects. Obviously,
+this takes time. You can integrate and use these projects in your applications *for free*! You can even change the source code and redistribute (even resell it).
 
-[PayPal donations][paypal-donations] are appreciated too! Each dollar helps.
+However, if you get some profit from this or just want to encourage me to continue creating stuff, there are few ways you can do it:
+
+ - Starring and sharing the projects you like :rocket:
+ - [![PayPal][badge_paypal]][paypal-donations]—You can make one-time donations via PayPal. I'll probably buy a ~~coffee~~ tea. :tea:
+ - [![Support me on Patreon][badge_patreon]][patreon]—Set up a recurring monthly donation and you will get interesting news about what I'm doing (things that I don't share with everyone).
+ - **Bitcoin**—You can send me bitcoins at this address (or scanning the code below): `1P9BRsmazNQcuyTxEqveUsnf5CERdq35V6`
+
+    ![](https://i.imgur.com/z6OQI95.png)
 
 Thanks! :heart:
+
 
 ## :dizzy: Where is this library used?
 If you are using this library in one of your projects, add it in this list. :sparkles:
@@ -294,7 +364,12 @@ If you are using this library in one of your projects, add it in this list. :spa
 
 [MIT][license] © [Ionică Bizău][website]
 
+[badge_patreon]: http://ionicabizau.github.io/badges/patreon.svg
+[badge_amazon]: http://ionicabizau.github.io/badges/amazon.svg
+[badge_paypal]: http://ionicabizau.github.io/badges/paypal.svg
+[badge_paypal_donate]: http://ionicabizau.github.io/badges/paypal_donate.svg
 [patreon]: https://www.patreon.com/ionicabizau
+[amazon]: http://amzn.eu/hRo9sIZ
 [paypal-donations]: https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=RVXDDLKKLQRJW
 [donate-now]: http://i.imgur.com/6cMbHOC.png
 

--- a/example/index.js
+++ b/example/index.js
@@ -3,9 +3,8 @@
 const Lien = require("../lib");
 
 // Init lien server
-let server = new Lien({
-    host: "localhost"
-  , port: 9000
+const server = new Lien({
+    port: 9000
   , public: __dirname + "/public"
 });
 
@@ -16,19 +15,19 @@ server.on("load", err => {
 });
 
 // Add page
-server.addPage("/", lien => {
+server.get("/", lien => {
     lien.end("Hello World");
 });
 
 // Add a dynamic route
-server.addPage("/post/:id", lien => {
+server.get("/post/:id", lien => {
     lien.end("Post id: " + lien.params.id);
 });
 
 // Add a static file
-server.addPage("/test", "/index.html");
-server.errorPages();
+server.get("/test", "index.html");
 
+// Listen for server errors
 server.on("serverError", err => {
     console.log(err.stack);
 });

--- a/example/index.js
+++ b/example/index.js
@@ -5,7 +5,7 @@ const Lien = require("../lib");
 // Init lien server
 const server = new Lien({
     port: 9000
-  , public: __dirname + "/public"
+  , public: `${__dirname}/public`
 });
 
 // Listen for load

--- a/example/login.js
+++ b/example/login.js
@@ -73,6 +73,32 @@ app.get("/post/:id", lien => {
     lien.end("Post id: " + lien.params.id);
 });
 
+app.use("/auth", (lien, next) => {
+    const username = lien.getSessionData("username");
+    lien.user = username ? {
+        name: username
+    } : null;
+    if (!lien.user) {
+        return lien.status(403).json({
+            error: "Unauthorized"
+        });
+    }
+    next();
+});
+
+app.get("/auth", lien => {
+    lien.end({
+        user: "/auth/user"
+    });
+});
+
+app.get("/auth/user", lien => {
+    lien.end({
+        foo: "Bar",
+        user: lien.user
+    });
+});
+
 app.get("/test", "/index.html");
 
 app.on("serverError", err => {

--- a/example/login.js
+++ b/example/login.js
@@ -10,9 +10,10 @@ const users = {
 const app = new Lien({
     host: "localhost"
   , port: 9000
-  , public: __dirname + "/public"
+  , public: `${__dirname}/public`
   , session: {
-        storeOptions: {
+        store: "connect-mongo"
+      , storeOptions: {
             url: "mongodb://localhost/test-app"
         }
     }
@@ -25,7 +26,7 @@ app.on("load", err => {
 });
 
 // Add page
-app.addPage("/", lien => {
+app.all("/", lien => {
     if (lien.getSessionData("logged_in")) {
         lien.file("logout.html");
     } else {
@@ -33,7 +34,7 @@ app.addPage("/", lien => {
     }
 });
 
-app.addPage("/api/login", "post", lien => {
+app.post("/api/login", lien => {
     if (!lien.data.username || !lien.data.password) {
         return lien.apiError("Incomplete data.");
     }
@@ -54,11 +55,11 @@ app.addPage("/api/login", "post", lien => {
     lien.apiError("Invalid credentials.", 403);
 });
 
-app.addPage("/api/session", lien => {
+app.get("/api/session", lien => {
     lien.end(lien.getSessionData());
 });
 
-app.addPage("/api/logout", "post", lien => {
+app.post("/api/logout", lien => {
     if (!lien.getSessionData("logged_in")) {
         return lien.apiError("You were not logged in anyways.");
     }
@@ -68,11 +69,11 @@ app.addPage("/api/logout", "post", lien => {
 });
 
 // Add a dynamic route
-app.addPage("/post/:id", lien => {
+app.get("/post/:id", lien => {
     lien.end("Post id: " + lien.params.id);
 });
 
-app.addPage("/test", "/index.html");
+app.get("/test", "/index.html");
 
 app.on("serverError", err => {
     console.log(err.stack);

--- a/lib/index.js
+++ b/lib/index.js
@@ -50,6 +50,7 @@ class LienObj {
             this.path = this.path.slice(0, -1) || "/";
         }
 
+        this.accepts = req.accepts.bind(req);
         this.host = req.hostname;
         this.params = req.params;
         this.query = req.query;
@@ -701,9 +702,9 @@ class Lien extends EventEmitter {
      */
     errorPages (options) {
         let sendResp = (lien, msg, status) => {
-            if (lien.req.accepts("html")) {
+            if (lien.accepts("html")) {
                 return lien.end(msg, status);
-            } else if (lien.req.accepts("json")) {
+            } else if (lien.accepts("json")) {
                 return lien.apiError(msg, status);
             }
             lien.end(msg, status, "txt");

--- a/lib/index.js
+++ b/lib/index.js
@@ -384,7 +384,8 @@ class LienObj {
  * It emits the following events:
  *
  *  - `load` (err): After the server is started. If there are no errors, the `err` will be null.
- *  - `serverError` (err, req, res): The server unexpected error.
+ *  - `serverError` (err, req, res): This is emitted when something goes wrong after the server is started.
+ *  - `error` (err): Errors which may appear during the server initialization.
  *
  * @name Lien
  * @function
@@ -501,6 +502,10 @@ class Lien extends EventEmitter {
                 this.SessionStoreModule = options.session.store;
             }
 
+            if (!this.SessionStoreModule && options.session.storeOptions) {
+                console.warn("Received store options, but no store was specified.");
+            }
+
             if (this.SessionStoreModule && options.session.storeOptions) {
                 this.SessionStore = this.SessionStoreModule(session);
                 options.session.store = new this.SessionStore(options.session.storeOptions);
@@ -546,6 +551,13 @@ class Lien extends EventEmitter {
 
         listenArgs.push(err => {
             this.emit("load", err);
+        });
+
+        ["all"].concat(httpMethods).forEach(method => {
+            if (this[method]) { return; }
+            this[method] = (url, output) => {
+                this.addPage(url, method, output);
+            };
         });
 
         // Start listening on host:port

--- a/lib/index.js
+++ b/lib/index.js
@@ -284,7 +284,7 @@ class LienObj {
         resData.status = status || 200;
         resData.headers = headers || {};
         resData.contentType = contentType
-        resData.lien = resData;
+        resData.lien = this;
 
         let trans = this.server.getHooks("after", this.path, this.method);
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -375,10 +375,10 @@ class LienObj {
     }
 }
 
-const RESPONSE_METHODS = ["append", "attachment", "download", "json", "jsonp", "links", "vary"];
+const RESPONSE_METHODS = ["append", "attachment", "download", "json", "jsonp", "links", "vary", "status"];
 RESPONSE_METHODS.forEach(method => {
     LienObj.prototype[method] = function () {
-        this.res[method].apply(this, arguments);
+        this.res[method].apply(this.res, arguments);
         return this;
     };
 });
@@ -852,6 +852,11 @@ class Lien extends EventEmitter {
             return this;
         }
 
+        if (Array.isArray(url)) {
+            url.forEach(u => this.hook(where, u, method, cb, transType));
+            return this;
+        }
+
         let customName = where.split(":");
 
         let trans = {};
@@ -869,6 +874,51 @@ class Lien extends EventEmitter {
 
         trans.add(cb, transType);
         return this;
+    }
+
+    /**
+     * before
+     * Adds a before hook. It will handle all the subroutes of the `url`.
+     *
+     * @name before
+     * @function
+     * @param {String} url The route url.
+     * @param {String} method The HTTP method.
+     * @param {Function} cb The callback function.
+     * @param {Number} transType The transformer type.
+     */
+    before (url, method, cb, transType) {
+        this.hook("before", url, method, cb, transType);
+    }
+
+    /**
+     * after
+     * Adds a before hook. It will handle all the subroutes of the `url`.
+     *
+     * @name after
+     * @function
+     * @param {String} url The route url.
+     * @param {String} method The HTTP method.
+     * @param {Function} cb The callback function.
+     * @param {Number} transType The transformer type.
+     */
+    after (url, method, cb, transType) {
+        this.hook("after", url, method, cb, transType);
+    }
+
+    /**
+     * use
+     * Use this function to add middleware handlers.
+     *
+     * @name use
+     * @function
+     * @param {String} url The route url.
+     * @param {String} method The HTTP method.
+     * @param {Function} cb The callback function.
+     * @param {Number} transType The transformer type.
+     */
+    use (url, method, cb, transType) {
+        this.before([url, `${url}/*`], method, cb, transType);
     }
 }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -217,11 +217,11 @@ class LienObj {
         }
 
         if (typeof name === "object") {
-            iterateObject(name, (value, name) => this.header(name, value));
-            return this;
+            this.res.set(name);
+        } else {
+            this.res.set(name, value);
         }
 
-        this.res.set(name, value);
         return this;
     }
 
@@ -374,6 +374,14 @@ class LienObj {
         this.res.sendFile(filePath);
     }
 }
+
+const RESPONSE_METHODS = ["append", "attachment", "download", "json", "jsonp", "links", "vary"];
+RESPONSE_METHODS.forEach(method => {
+    LienObj.prototype[method] = function () {
+        this.res[method].apply(this, arguments);
+        return this;
+    };
+});
 
 /**
  * Lien

--- a/lib/index.js
+++ b/lib/index.js
@@ -12,7 +12,6 @@ const events = require("events")
     , toBuffer = require("./to-buffer")
     , session = require("express-session")
     , findValue = require("find-value")
-    , connectMongo = require("connect-mongo")
     , qs = require("querystring")
     , parseUrl = require("parse-url")
     , Transformer = require("transformer")
@@ -398,8 +397,8 @@ class LienObj {
  *    - `resave` (Boolean): Forces the session to be saved back to the session store, even if the session was never modified during the request (default: false).
  *    - `saveUninitialized` (Boolean): Forces a session that is "uninitialized" to be saved to the store (default: `true`).
  *    - `cookie` (Object): The cookie [options](https://github.com/expressjs/cookie-parser).
- *    - `storeOptions` (Object): The [MongoStore options](https://github.com/kcbanner/connect-mongo).
- *    - `store`: (Object): A custom store object (optional, as long `storeOptions` is provided).
+ *    - `storeOptions` (Object): The session store options. These options are passed to the session store you choose.
+ *    - `store`: (String|Function): The session store name or function. By default it's using a memory store if the session is enabled.
  *  - `public` (String|Array): The path to the public directory or an array of arrays in this format: `["/url/of/static/dir", "path/to/static/dir"]`.
  *
  *    Example:
@@ -443,6 +442,8 @@ class Lien extends EventEmitter {
           , logErrors: true
           , csrf: null
           , port: process.env.PORT || 3000
+          , cookieSecret: "lien"
+          , cookieOptions: {}
         });
 
         if (options.csrf === true) {
@@ -471,25 +472,41 @@ class Lien extends EventEmitter {
         app.use(bodyParser.json());
         app.use(bodyParser.urlencoded({ extended: true }));
 
-        this.MongoStore = connectMongo(session);
+        this.SessionStore = null;
+        this.SessionStoreModule = null;
 
-        app.use(cookieParser());
+        app.use(cookieParser(options.cookieSecret, options.cookieOptions));
 
         if (options.session) {
             options.session = ul.merge(options.session, {
-                secret: "lien server"
-              , resave: false
+                resave: false
               , saveUninitialized: true
-              , cookie: {}
               , store: null
               , storeOptions: {}
             });
+            options.session.secret = options.cookieSecret;
 
-            if (!options.session.store && options.session.storeOptions) {
-                options.session.store = new this.MongoStore(options.session.storeOptions);
+            // Store name provided
+            if (typeof options.session.store === "string") {
+                try {
+                    this.SessionStoreModule = require(options.session.store);
+                } catch (e) {
+                    if (e.code === "MODULE_NOT_FOUND") {
+                        this.emit("error", new Error(`The ${options.session.store} should be installed in your app to use it as session store.`));
+                    } else {
+                        this.emit("error", e);
+                    }
+                }
+            } else if (typeof options.session.store === "function") {
+                this.SessionStoreModule = options.session.store;
             }
 
-            delete options.storeOptions;
+            if (this.SessionStoreModule && options.session.storeOptions) {
+                this.SessionStore = this.SessionStoreModule(session);
+                options.session.store = new this.SessionStore(options.session.storeOptions);
+            } else if (!this.SessionStoreModule && this.app.get("env") === "production") {
+                console.warn("You are using a memory session store in production. This may cause memory leaks. Please consider using a database store.");
+            }
 
             this.session = session(options.session);
             this.app.use(this.session);
@@ -541,6 +558,16 @@ class Lien extends EventEmitter {
         }
     }
 
+    /**
+     * addStaticPath
+     * Adds a new static path to the server.
+     *
+     * @name addStaticPath
+     * @function
+     * @static
+     * @param {String} url The static path url endpoint.
+     * @param {String} localPath The local path to the directory.
+     */
     addStaticPath (url, localPath) {
         this.app.use(url, express.static(localPath));
     }

--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
   },
   "dependencies": {
     "body-parser": "^1.15.0",
-    "connect-mongo": "^1.1.0",
     "cookie-parser": "^1.4.3",
     "csurf": "^1.9.0",
     "express": "^4.13.4",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "test": "node test/index.js"
   },
   "name": "lien",
-  "version": "2.3.0",
+  "version": "3.0.0",
   "description": "Another lightweight NodeJS framework. Lien is the link between request and response objects.",
   "main": "lib/index.js",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   },
   "devDependencies": {
     "ajs": "^1.2.1",
+    "connect-mongo": "^1.3.2",
     "tester": "^1.3.4",
     "tinyreq": "^3.1.2"
   },

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "test": "node test/index.js"
   },
   "name": "lien",
-  "version": "3.0.0",
+  "version": "3.0.0-alpha",
   "description": "An easy to use web framework for Node.js.",
   "main": "lib/index.js",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "test": "node test/index.js"
   },
   "name": "lien",
-  "version": "2.3.1",
+  "version": "3.0.0",
   "description": "An easy to use web framework for Node.js.",
   "main": "lib/index.js",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   },
   "name": "lien",
   "version": "3.0.0",
-  "description": "Another lightweight NodeJS framework. Lien is the link between request and response objects.",
+  "description": "An easy to use web framework for Node.js.",
   "main": "lib/index.js",
   "keywords": [
     "lien",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "test": "node test/index.js"
   },
   "name": "lien",
-  "version": "3.0.0-alpha",
+  "version": "2.3.1",
   "description": "An easy to use web framework for Node.js.",
   "main": "lib/index.js",
   "keywords": [


### PR DESCRIPTION
## :boom: MongoDB

Fixes #52.

MongoDB is not used as default session store anymore. The developer should configure the store if they want session support in their app:

```js
{
    session: {
        store: "connect-mongo"
      , storeOptions: {
           url: "mongodb://localhost/test-app"
        }
    }
}
```

## New Methods :rocket: 

Added aliases for `addPage(..., <method>, ...)`:

 - `.get(...)`
 - `.post(...)`
 - `.head(...)`
 - `.all(...)`
 - ... and so on

## It's simpler to create middlewares :microscope: 

Using the `before`, `after` and `use` helpers we can define middlewares and hooks.